### PR TITLE
add jessie support + tests

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+use_librato: false
+use_instrumental: false
+use_ducksboard: false
+use_graphite: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: debian
       versions:
         - wheezy
+        - jessie
     - name: ubuntu
       versions:
         - all

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,0 +1,12 @@
+---
+name: "Aeriscloud.statsd"
+playbook:
+- hosts: all
+  sudo: true
+  roles:
+  - role: "@ROLE_NAME@"
+  tasks:
+  - name: "Ensure statsd is running"
+    service:
+      name: statsd
+      state: started


### PR DESCRIPTION
This PR adds support for Debian Jessie + tests + default variables off using librato, instrumental, ducksboard and graphite.
